### PR TITLE
Fix widget preview and embed codes.

### DIFF
--- a/CRM/Wci/Form/CreateWidget.php
+++ b/CRM/Wci/Form/CreateWidget.php
@@ -43,6 +43,11 @@ class CRM_Wci_Form_CreateWidget extends CRM_Core_Form {
   function preProcess() {
     CRM_Core_Resources::singleton()->addScriptFile('com.zyxware.civiwci', 'js/createwidget.js');
     parent::preProcess();
+
+    if(isset($_REQUEST['id'])) {
+      $this->assign('emb_id', $_REQUEST['id']);
+    }
+
     $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this,
           FALSE, NULL, 'REQUEST' );
 

--- a/CRM/Wci/Form/NewEmbedCode.php
+++ b/CRM/Wci/Form/NewEmbedCode.php
@@ -34,6 +34,10 @@ class CRM_Wci_Form_NewEmbedCode extends CRM_Core_Form {
   protected $_id;
 
   function preProcess() {
+      if(isset($_REQUEST['id'])) {
+        $this->assign('emb_id', $_REQUEST['id']);
+      }
+
       $this->_id = CRM_Utils_Request::retrieve('id', 'Positive', $this,
           FALSE, NULL, 'REQUEST' );
   }

--- a/CRM/Wci/Page/Embed.php
+++ b/CRM/Wci/Page/Embed.php
@@ -4,6 +4,7 @@
  | CiviCRM Widget Creation Interface (WCI) Version 1.0                |
  +--------------------------------------------------------------------+
  | Copyright Zyxware Technologies (c) 2014                            |
+ | Copyright (C) 2014 David Thompson <davet@gnu.org>                  |
  +--------------------------------------------------------------------+
  | This file is a part of CiviCRM WCI.                                |
  |                                                                    |
@@ -21,16 +22,12 @@
  | Technologies at info[AT]zyxware[DOT]com.                           |
  +--------------------------------------------------------------------+
 */
-/**
- *
- * @package CRM
- * @copyright CiviCRM LLC (c) 2004-2013
- * $Id$
- */
 
-require_once '../../../civicrm.config.php';
+require_once 'CRM/Core/Page.php';
 
-$license_text = '
+class CRM_Wci_Page_Embed extends CRM_Core_Page {
+  function run() {
+    $license_text = '
 /**
  * @licstart The following is the entire license notice for the JavaScript
  * code included by CiviCRM WCI extension.
@@ -49,7 +46,8 @@ $license_text = '
  * code included by CiviCRM WCI extension.
  */
 ';
-$wciembed_js = '
+
+    $wciembed_js = '
 // Cleanup functions for the document ready method
 if ( document.addEventListener ) {
     DOMContentLoaded = function() {
@@ -90,15 +88,17 @@ function onReady( ) {
   document.getElementById("widgetwci").innerHTML = wciwidgetcode;
 }';
 
-$config = CRM_Core_Config::singleton();
+    $config = CRM_Core_Config::singleton();
 
-$embedId = CRM_Utils_Request::retrieve('id', 'Positive', CRM_Core_DAO::$_nullObject);
-$preview = CRM_Utils_Request::retrieve('preview', 'Positive', CRM_Core_DAO::$_nullObject);
+    $embedId = CRM_Utils_Request::retrieve('id', 'Positive', CRM_Core_DAO::$_nullObject);
+    $preview = CRM_Utils_Request::retrieve('preview', 'Positive', CRM_Core_DAO::$_nullObject);
 
-$output  = $license_text;
-$output .= 'var wciwidgetcode =  ' . CRM_Wci_WidgetCode::get_widget_code($embedId, $preview) . ';';
-$output .= $wciembed_js;
+    $output  = $license_text;
+    $output .= 'var wciwidgetcode =  ' . CRM_Wci_WidgetCode::get_widget_code($embedId, $preview) . ';';
+    $output .= $wciembed_js;
 
-echo $output;
-
-CRM_Utils_System::civiExit();
+    header('Content-Type: text/javascript');
+    echo $output;
+    CRM_Utils_System::civiExit();
+  }
+}

--- a/CRM/Wci/WidgetCode.php
+++ b/CRM/Wci/WidgetCode.php
@@ -22,7 +22,7 @@
  +--------------------------------------------------------------------+
 */
 
-require_once '../wci-helper-functions.php';
+require_once 'wci-helper-functions.php';
 
 class CRM_Wci_WidgetCode {
 

--- a/templates/CRM/Wci/Form/CreateWidget.tpl
+++ b/templates/CRM/Wci/Form/CreateWidget.tpl
@@ -3,6 +3,7 @@
  | CiviCRM Widget Creation Interface (WCI) Version 1.0                |
  +--------------------------------------------------------------------+
  | Copyright Zyxware Technologies (c) 2014                            |
+ | Copyright (C) 2014 David Thompson <davet@gnu.org>                  |
  +--------------------------------------------------------------------+
  | This file is a part of CiviCRM WCI.                                |
  |                                                                    |
@@ -27,13 +28,6 @@
   </div>
 
   {if $form.title.value != ""}
-    {php}
-      if(isset($_REQUEST['id'])) {
-        $widget_controller_path = getWciWidgetControllerPath();
-        $extension_root_path = getExtensionRootPath();
-      }
-    {/php}
-
     <div class="crm-section">
       <div class="label">Widget Preview</div>
         <div class="content">
@@ -42,7 +36,7 @@
           <div class="description">
             Click <strong>Save &amp; Preview</strong> to save any changes to your settings, and preview the widget again on this page.
           </div>
-          <script type="text/javascript" src="{php}echo $widget_controller_path;{/php}?id={php}echo $_REQUEST['id'];{/php}&preview=1"></script>
+          <script type="text/javascript" src="{crmURL p='civicrm/wci/embed' q="id=`$emb_id`&preview=1"}"></script>
   <div id='widgetwci'></div>{help id="preview" file="CRM/Wci/Form/CreateWidget"}
         </div>
     </div>

--- a/templates/CRM/Wci/Form/NewEmbedCode.tpl
+++ b/templates/CRM/Wci/Form/NewEmbedCode.tpl
@@ -3,6 +3,7 @@
  | CiviCRM Widget Creation Interface (WCI) Version 1.0                |
  +--------------------------------------------------------------------+
  | Copyright Zyxware Technologies (c) 2014                            |
+ | Copyright (C) 2014 David Thompson <davet@gnu.org>                  |
  +--------------------------------------------------------------------+
  | This file is a part of CiviCRM WCI.                                |
  |                                                                    |
@@ -35,16 +36,8 @@
     <div class="clear"></div>
   </div>
 {/foreach}
-  {if $form.title.value != ""}
-    {php}
-      if(isset($_REQUEST['id'])) {
-        $emb_id = $_REQUEST['id'];
-        $wid_id = CRM_Wci_BAO_EmbedCode::getWidgetId($emb_id);
-        $widget_controller_path = getWciWidgetControllerPath();
-        $extension_root_path = getExtensionRootPath();
-      }
-    {/php}
 
+  {if $form.title.value != ""}
     <div class="crm-section">
       <fieldset>
         <legend>
@@ -54,15 +47,17 @@
           <div class="description">
             Click <strong>Save &amp; Preview</strong> to save any changes to your settings, and preview the widget again on this page.
           </div>
-          <script type="text/javascript" src="{php}echo $widget_controller_path;{/php}?id={php}echo $wid_id;{/php}&preview=1"></script></script>
-  <div id='widgetwci'></div>
+          <script type="text/javascript" src="{crmURL p='civicrm/wci/embed' q="id=`$emb_id`&preview=1"}"></script>
+          <div id="widgetwci"></div>
         </div>
         <div class="col2">
           <div class="description">
             Add this widget to any web page by copying and pasting the code below.
           </div>
-          <textarea rows="8" cols="40" name="widget_code" id="widget_code"><script type="text/javascript" src="{php}echo $widget_controller_path;{/php}?id={php}echo $emb_id;{/php}&referal_id=2442"> </script>
-<div id='widgetwci'></div></textarea>
+          <textarea rows="8" cols="40" name="widget_code" id="widget_code">
+<script type="text/javascript" src="{crmURL p='civicrm/wci/embed' q="id=`$emb_id`&referral_id=2442" a=1}"></script>
+<div id="widgetwci"></div>
+          </textarea>
           <br>
           <strong>
             <a href="#" onclick="NewEmbedCode.widget_code.select(); return false;">» Select Code</a>

--- a/wci-helper-functions.php
+++ b/wci-helper-functions.php
@@ -35,16 +35,6 @@
     return $options;
   }
 
-  function getExtensionRootPath() {
-    return 'http://' . $_SERVER['SERVER_NAME'] . str_replace($_SERVER['DOCUMENT_ROOT'], '', __DIR__);
-  }
-
-  function getWciWidgetControllerPath() {
-    $widget_controller_path = getExtensionRootPath() . '/extern/embed.php';
-
-    return $widget_controller_path;
-  }
-
   function getWciWidgetTemplatePath() {
     $widget_tpl_path = __DIR__ . '/templates/CRM/Wci/Page';
 

--- a/xml/Menu/wci.xml
+++ b/xml/Menu/wci.xml
@@ -48,4 +48,10 @@
     <title>ManageEmbedCode</title>
     <access_arguments>access CiviCRM</access_arguments>
   </item>
+  <item>
+    <path>civicrm/wci/embed</path>
+    <page_callback>CRM_Wci_Page_Embed</page_callback>
+    <title>Embed</title>
+    <access_arguments>access CiviCRM</access_arguments>
+  </item>
 </menu>


### PR DESCRIPTION
The existing widget embedding system relied on a few of assumptions:
- It always used HTTP, which results in a security policy issue, see: https://developer.mozilla.org/en-US/docs/Security/MixedContent
- It assumed that the `extern/embed.php` script was accessible on the web server via its absolute path
- That there is a file called `civicrm.config.php` three directories beneath `extern`.

This patch creates a CRM page instead of an external script that generates the embeddable JavaScript and uses the `crmURL` function to generate correct URLs according to the way the CiviCRM instance is configured.

This was tested on the FSF's development CiviCRM instance.
