### PR TITLE
Fix LibreJS metadata in embeddable JavaScript.

### DIFF
--- a/CRM/Wci/Page/Embed.php
+++ b/CRM/Wci/Page/Embed.php
@@ -29,21 +29,29 @@ class CRM_Wci_Page_Embed extends CRM_Core_Page {
   function run() {
     $license_text = '
 /**
- * @licstart The following is the entire license notice for the JavaScript
- * code included by CiviCRM WCI extension.
+ * @licstart The following is the entire license notice for the
+ *   JavaScript code in this page.
  *
  * Copyright (C) 2014 Zyxware Technologies.
  *
- * This JavaScript is part of the  CiviCRM WCI extension for CiviCRM. This
- * JavaScript is free software: you can redistribute it and/or modify it under the
- * terms of the GNU Affero General Public License (GNU AGPL) as published by the
- * Free Software Foundation, either version 3 of the License, or (at your option)
- * any later version. The code is distributed WITHOUT ANY WARRANTY; without even
- * the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU AGPL for more details.
+ * This JavaScript is part of the CiviCRM WCI extension for
+ * CiviCRM. This JavaScript is free software: you can
+ * redistribute it and/or modify it under the terms of the GNU
+ * Affero General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
  *
- * @licend The above is the entire license notice for the JavaScript
- * code included by CiviCRM WCI extension.
+ * The code is distributed WITHOUT ANY WARRANTY; without even the
+ * implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE.  See the GNU Affero General Public License
+ * for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with FSF Member Dashboard.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * @licend The above is the entire license notice for the
+ *   JavaScript code in this page
  */
 ';
 


### PR DESCRIPTION
LibreJS is a little strange in how it detects a license as a valid free software license.  The regexps aren't flexible enough, IMO.  This patch makes LibreJS happy.  Tested with version 6.0.6.
